### PR TITLE
Skip if NODE_ENV environment is "development".

### DIFF
--- a/src/heroku-keepalive.coffee
+++ b/src/heroku-keepalive.coffee
@@ -17,6 +17,8 @@
 #   Josh Nichols <technicalpickles@github.com>
 
 module.exports = (robot) ->
+  return if process.env.NODE_ENV is 'development'
+
   keepaliveUrl = process.env.HUBOT_HEROKU_KEEPALIVE_URL or process.env.HEROKU_URL
   if keepaliveUrl and not keepaliveUrl.match(/\/$/)
     keepaliveUrl = "#{keepaliveUrl}/"


### PR DESCRIPTION
Hi! I tried to fix https://github.com/hubot-scripts/hubot-heroku-keepalive/issues/6.
This patch provides an option. During set `NODE_ENV` as 'development', skip process without warning; Implementation for Plan A of https://github.com/hubot-scripts/hubot-heroku-keepalive/issues/6

> - look at NODE_ENV, and don't warn during development

But actually, I have a concern.
As a default, [Heroku does not provide `NODE_ENV` environment](https://devcenter.heroku.com/articles/nodejs-support#runtime-behavior).
Many hubot users don't use `NODE_ENV` on both production(Heroku) and development(local machine) normally, I think. Then should we create brand-new environment variable? My opinion is "less is better", but there is little difference in this case.

I may need your advice.
Thanks.