### PR TITLE
Soon, heroku dynos will be forced to sleep 6 hours a day 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,23 @@ Then add **hubot-heroku-keepalive** to your `external-scripts.json`:
 
 ## Configuring
 
-hubot-heroku-keepalive is configured by two environment variables:
+hubot-heroku-keepalive is configured by four environment variables:
 
 * HUBOT_HEROKU_KEEPALIVE_URL - the URL to keepalive
 * HUBOT_HEROKU_KEEPALIVE_INTERVAL - the interval in which to keepalive, in minutes
+* HUBOT_HEROKU_WAKEUP_TIME - optional,  the time of day (HH:MM) when hubot should wake up.  Default 6:00 (6 am)
+* HUBOT_HEROKU_SLEEP_TIME - optional, the time of day (HH:MM) when hubot should go to sleep. Default 22:00 (10 pm)
+
+In May, 2015, Heroku introduced a [new pricing tier](https://blog.heroku.com/archives/2015/5/7/new-dyno-types-public-beta)
+doing away with a 24/7 free dyno. `HUBOT_HEROKU_WAKEUP_TIME` and
+`HUBOT_HEROKU_SLEEP_TIME` define the waking hours - between these times the keepalive
+will ping your Heroku app.  Outside of those times, the ping will be surpressed
+allowing the dyno to shut down.  Accessing your Hubot during a sleep period will
+wake it, but it will return to sleep after 30 minutes.  `HUBOT_HEROKU_WAKEUP_TIME`
+and `HUBOT_HEROKU_SLEEP_TIME` are times based on the timezone of your Heroku
+application which defaults to UTC.  You can change this with
+`heroku config:add TZ="America/New_York"`
+
 
 For hubot-heroku-keepalive to be useful, you *must* at least set
 HUBOT_HEROKU_KEEPALIVE_URL. You can find out the value for this by using the

--- a/README.md
+++ b/README.md
@@ -30,10 +30,14 @@ doing away with a 24/7 free dyno. `HUBOT_HEROKU_WAKEUP_TIME` and
 `HUBOT_HEROKU_SLEEP_TIME` define the waking hours - between these times the keepalive
 will ping your Heroku app.  Outside of those times, the ping will be surpressed
 allowing the dyno to shut down.  Accessing your Hubot during a sleep period will
-wake it, but it will return to sleep after 30 minutes.  `HUBOT_HEROKU_WAKEUP_TIME`
+wake it, but it will return to sleep after 30 minutes.  
+
+`HUBOT_HEROKU_WAKEUP_TIME`
 and `HUBOT_HEROKU_SLEEP_TIME` are times based on the timezone of your Heroku
 application which defaults to UTC.  You can change this with
-`heroku config:add TZ="America/New_York"`
+`heroku config:add TZ="America/New_York"`.
+
+You must still implement a process to wake the heroku app up in the morning, such as a cron job or a custom command that posts to your heroku instance from your chat.
 
 
 For hubot-heroku-keepalive to be useful, you *must* at least set

--- a/src/heroku-keepalive.coffee
+++ b/src/heroku-keepalive.coffee
@@ -3,11 +3,17 @@
 #
 # Notes:
 #   This replaces hubot's builtin Heroku keepalive behavior. It uses the same
-#   environment variable (HEROKU_URL), but removes the period ping.
+#   environment variable (HEROKU_URL), but removes the period ping.  Pings will
+#   only occur between the WAKEUP_TIME and SLEEP_TIME in the timezone your
+#   heroku instance is running in (UTC by default).
 #
 # Configuration:
 #   HUBOT_HEROKU_KEEPALIVE_URL or HEROKU_URL: required
 #   HUBOT_HEROKU_KEEPALIVE_INTERVAL: optional, defaults to 5 minutes
+#   HUBOT_HEROKU_WAKEUP_TIME: optional, defaults to 6:00 (6 AM).
+#   HUBOT_HEROKU_SLEEP_TIME: optional, defaults to 22:00 (10 PM)
+#
+#   heroku config:add TZ="America/New_York"
 #
 # URLs:
 #   GET /heroku/keepalive
@@ -17,6 +23,12 @@
 #   Josh Nichols <technicalpickles@github.com>
 
 module.exports = (robot) ->
+  wakeUpTime = (process.env.HUBOT_HEROKU_WAKEUP_TIME or '6:00').split(':')
+  sleepTime = (process.env.HUBOT_HEROKU_SLEEP_TIME or '22:00').split(':')
+
+  wakeUpOffset = 60 * wakeUpTime[0]  + 1 * wakeUpTime[1]
+  sleepOffset  = 60 * sleepTime[0]   + 1 * sleepTime[1]
+
   keepaliveUrl = process.env.HUBOT_HEROKU_KEEPALIVE_URL or process.env.HEROKU_URL
   if keepaliveUrl and not keepaliveUrl.match(/\/$/)
     keepaliveUrl = "#{keepaliveUrl}/"
@@ -38,12 +50,20 @@ module.exports = (robot) ->
   if keepaliveInterval > 0.0
     robot.herokuKeepaliveIntervalId = setInterval =>
       robot.logger.info 'keepalive ping'
-      robot.http("#{keepaliveUrl}heroku/keepalive").post() (err, res, body) =>
-        if err?
-          robot.logger.info "keepalive pong: #{err}"
-          robot.emit 'error', err
-        else
-          robot.logger.info "keepalive pong: #{res.statusCode} #{body}"
+
+      now = new Date()
+      nowOffset    = 60 * now.getHours() + now.getMinutes()
+
+      if (nowOffset >= wakeUpOffset && nowOffset < sleepOffset)
+        robot.http("#{keepaliveUrl}heroku/keepalive").post() (err, res, body) =>
+          if err?
+            robot.logger.info "keepalive pong: #{err}"
+            robot.emit 'error', err
+          else
+            robot.logger.info "keepalive pong: #{res.statusCode} #{body}"
+      else
+        robot.logger.info "Skipping keep alive, time to rest"
+
     , keepaliveInterval * 60 * 1000
   else
     robot.logger.info "hubot-heroku-keepalive is #{keepaliveInterval}, so not keeping alive"


### PR DESCRIPTION
One way to fix #8.  

No more bot abuse without paying for it.    This adds two optional configuration parameters to the keep alive: ```HUBOT_HEROKU_WAKEUP_TIME``` and ```HUBOT_HEROKU_SLEEP_TIME```. The keep alive ping will only be sent if the current time (of the heroku instance) is between those two times. 

There are some limitations / warnings: default time is UTC, you can change it with ```heroku config:add TZ="America/New_York"```.  The walkup time and sleep time have to be in the same day.  You can't for instance say "wake up at 10 pm and go to sleep at 4 am" and you only get one period per day.  You can achieve 10pm to 4am by changing the TZ of your heroku app.

I don't quite feel this is complete, I'm fairly new to coffeescript and node and there is no way to turn off the time check.  I'm planning on using this on our instance and refining but I wanted to share.
