### PR TITLE
Heroku scheduler to wake dynos

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,23 @@ Then add **hubot-heroku-keepalive** to your `external-scripts.json`:
 
 ## Configuring
 
-hubot-heroku-keepalive is configured by two environment variables:
+hubot-heroku-keepalive is configured by four environment variables:
 
 * HUBOT_HEROKU_KEEPALIVE_URL - the URL to keepalive
 * HUBOT_HEROKU_KEEPALIVE_INTERVAL - the interval in which to keepalive, in minutes
+* HUBOT_HEROKU_WAKEUP_TIME - optional,  the time of day (HH:MM) when hubot should wake up.  Default 6:00 (6 am)
+* HUBOT_HEROKU_SLEEP_TIME - optional, the time of day (HH:MM) when hubot should go to sleep. Default 22:00 (10 pm)
+
+In May, 2015, Heroku introduced a [new pricing tier](https://blog.heroku.com/archives/2015/5/7/new-dyno-types-public-beta)
+doing away with a 24/7 free dyno. `HUBOT_HEROKU_WAKEUP_TIME` and
+`HUBOT_HEROKU_SLEEP_TIME` define the waking hours - between these times the keepalive
+will ping your Heroku app.  Outside of those times, the ping will be surpressed
+allowing the dyno to shut down.  Accessing your Hubot during a sleep period will
+wake it, but it will return to sleep after 30 minutes.  `HUBOT_HEROKU_WAKEUP_TIME`
+and `HUBOT_HEROKU_SLEEP_TIME` are times based on the timezone of your Heroku
+application which defaults to UTC.  You can change this with
+`heroku config:add TZ="America/New_York"`
+
 
 For hubot-heroku-keepalive to be useful, you *must* at least set
 HUBOT_HEROKU_KEEPALIVE_URL. You can find out the value for this by using the

--- a/README.md
+++ b/README.md
@@ -30,10 +30,14 @@ doing away with a 24/7 free dyno. `HUBOT_HEROKU_WAKEUP_TIME` and
 `HUBOT_HEROKU_SLEEP_TIME` define the waking hours - between these times the keepalive
 will ping your Heroku app.  Outside of those times, the ping will be surpressed
 allowing the dyno to shut down.  Accessing your Hubot during a sleep period will
-wake it, but it will return to sleep after 30 minutes.  `HUBOT_HEROKU_WAKEUP_TIME`
+wake it, but it will return to sleep after 30 minutes.  
+
+`HUBOT_HEROKU_WAKEUP_TIME`
 and `HUBOT_HEROKU_SLEEP_TIME` are times based on the timezone of your Heroku
 application which defaults to UTC.  You can change this with
-`heroku config:add TZ="America/New_York"`
+`heroku config:add TZ="America/New_York"`.
+
+You must still implement a process to wake the heroku app up in the morning, such as a cron job or a custom command that posts to your heroku instance from your chat.
 
 
 For hubot-heroku-keepalive to be useful, you *must* at least set

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ heroku config:add TZ="America/New_York"
 
 ## Waking Hubot Up
 
-This script will the dyno alive once it is awake, but something needs to wake it up. You can use the [Heroku Scheduler](https://devcenter.heroku.com/articles/scheduler) to wake the dyno up. Add the scheduler addon by running:
+This script will keep the dyno alive once it is awake, but something needs to wake it up. You can use the [Heroku Scheduler](https://devcenter.heroku.com/articles/scheduler) to wake the dyno up. Add the scheduler addon by running:
 
 ```
 heroku addons:create scheduler:standard

--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ heroku config:set HUBOT_HEROKU_KEEPALIVE_URL=$(heroku apps:info -s  | grep web_u
 heroku config:add TZ="America/New_York"
 ```
 
+## Waking Hubot Up
+
+This script will the dyno alive once it is awake, but something needs to wake it up. You can use the [Heroku Scheduler](https://devcenter.heroku.com/articles/scheduler) to wake the dyno up. Add the scheduler addon by running:
+
+```
+heroku addons:create scheduler:standard
+```
+
+The scheduler must be manually configured from the web interface, so run `heroku addons:open scheduler` and configure it to run `curl ${HUBOT_HEROKU_KEEPALIVE_URL}heroku/keepalive` at the time configured for `HUBOT_HEROKU_WAKEUP_TIME`.
+
+![Heroku Scheduler Screenshot](https://cloud.githubusercontent.com/assets/173/9414275/2e4b67ea-4805-11e5-80d0-d6b26ead50ef.png)
+
 ## Legacy Support
 
 Hubot has for a long time had it's own builtin way to keep its web dyno alive,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # hubot-heroku-keepalive
 
-A hubot script that keeps the hubot Heroko web dyno alive.
+A hubot script that keeps the hubot Heroko free web dyno alive.
+
+Note that a [free Heroku dyno can only run for 18 hours/day](https://blog.heroku.com/archives/2015/5/7/new-dyno-types-public-beta#hobby-and-free-dynos), so it will be required to sleep for at least 6 hours. Accessing your Hubot during a sleep period will wake it, but it will return to sleep after 30 minutes.
 
 ## Installation
 
@@ -20,35 +22,12 @@ Then add **hubot-heroku-keepalive** to your `external-scripts.json`:
 
 hubot-heroku-keepalive is configured by four environment variables:
 
-* HUBOT_HEROKU_KEEPALIVE_URL - the URL to keepalive
-* HUBOT_HEROKU_KEEPALIVE_INTERVAL - the interval in which to keepalive, in minutes
-* HUBOT_HEROKU_WAKEUP_TIME - optional,  the time of day (HH:MM) when hubot should wake up.  Default 6:00 (6 am)
-* HUBOT_HEROKU_SLEEP_TIME - optional, the time of day (HH:MM) when hubot should go to sleep. Default 22:00 (10 pm)
+* `HUBOT_HEROKU_KEEPALIVE_URL` - required, the URL to keepalive
+* `HUBOT_HEROKU_WAKEUP_TIME` - optional,  the time of day (HH:MM) when hubot should wake up.  Default: 6:00 (6 am)
+* `HUBOT_HEROKU_SLEEP_TIME` - optional, the time of day (HH:MM) when hubot should go to sleep. Default: 22:00 (10 pm)
+* `HUBOT_HEROKU_KEEPALIVE_INTERVAL` - the interval in which to keepalive, in minutes. Default: 5
 
-In May, 2015, Heroku introduced a [new pricing tier](https://blog.heroku.com/archives/2015/5/7/new-dyno-types-public-beta)
-doing away with a 24/7 free dyno. `HUBOT_HEROKU_WAKEUP_TIME` and
-`HUBOT_HEROKU_SLEEP_TIME` define the waking hours - between these times the keepalive
-will ping your Heroku app.  Outside of those times, the ping will be surpressed
-allowing the dyno to shut down.  Accessing your Hubot during a sleep period will
-wake it, but it will return to sleep after 30 minutes.  
-
-`HUBOT_HEROKU_WAKEUP_TIME`
-and `HUBOT_HEROKU_SLEEP_TIME` are times based on the timezone of your Heroku
-application which defaults to UTC.  You can change this with
-`heroku config:add TZ="America/New_York"`.
-
-You must still implement a process to wake the heroku app up in the morning, such as a cron job or a custom command that posts to your heroku instance from your chat.
-
-
-For hubot-heroku-keepalive to be useful, you *must* at least set
-HUBOT_HEROKU_KEEPALIVE_URL. You can find out the value for this by using the
-[Heroku Toolbelt](https://toolbelt.heroku.com/):
-
-```
-heroku apps:info
-```
-
-Copy the `Web URL`, and then `config:set` HUBOT_HEROKU_KEEPALIVE_URL:
+You *must* set `HUBOT_HEROKU_KEEPALIVE_URL`. You can find out the value for this by running `heroku apps:info`. Copy the `Web URL` and run:
 
 ```
 heroku config:set HUBOT_HEROKU_KEEPALIVE_URL=PASTE_WEB_URL_HERE
@@ -58,6 +37,12 @@ If you want to trust a shell snippet from the Internet, here's a one-liner:
 
 ```
 heroku config:set HUBOT_HEROKU_KEEPALIVE_URL=$(heroku apps:info -s  | grep web_url | cut -d= -f2)
+```
+
+`HUBOT_HEROKU_WAKEUP_TIME` and `HUBOT_HEROKU_SLEEP_TIME` define the waking hours - between these times the keepalive will ping your Heroku app.  Outside of those times, the ping will be suppressed, allowing the dyno to shut down. These times are based on the timezone of your Heroku application which defaults to UTC.  You can change this with:
+
+```
+heroku config:add TZ="America/New_York"
 ```
 
 ## Legacy Support

--- a/src/heroku-keepalive.coffee
+++ b/src/heroku-keepalive.coffee
@@ -3,11 +3,17 @@
 #
 # Notes:
 #   This replaces hubot's builtin Heroku keepalive behavior. It uses the same
-#   environment variable (HEROKU_URL), but removes the period ping.
+#   environment variable (HEROKU_URL), but removes the period ping.  Pings will
+#   only occur between the WAKEUP_TIME and SLEEP_TIME in the timezone your
+#   heroku instance is running in (UTC by default).
 #
 # Configuration:
 #   HUBOT_HEROKU_KEEPALIVE_URL or HEROKU_URL: required
 #   HUBOT_HEROKU_KEEPALIVE_INTERVAL: optional, defaults to 5 minutes
+#   HUBOT_HEROKU_WAKEUP_TIME: optional, defaults to 6:00 (6 AM).
+#   HUBOT_HEROKU_SLEEP_TIME: optional, defaults to 22:00 (10 PM)
+#
+#   heroku config:add TZ="America/New_York"
 #
 # URLs:
 #   GET /heroku/keepalive
@@ -17,6 +23,12 @@
 #   Josh Nichols <technicalpickles@github.com>
 
 module.exports = (robot) ->
+  wakeUpTime = (process.env.HUBOT_HEROKU_WAKEUP_TIME or '6:00').split(':')
+  sleepTime = (process.env.HUBOT_HEROKU_SLEEP_TIME or '22:00').split(':')
+
+  wakeUpOffset = 60 * wakeUpTime[0]  + 1 * wakeUpTime[1]
+  sleepOffset  = 60 * sleepTime[0]   + 1 * sleepTime[1]
+
   keepaliveUrl = process.env.HUBOT_HEROKU_KEEPALIVE_URL or process.env.HEROKU_URL
   if keepaliveUrl and not keepaliveUrl.match(/\/$/)
     keepaliveUrl = "#{keepaliveUrl}/"
@@ -38,12 +50,20 @@ module.exports = (robot) ->
   if keepaliveInterval > 0.0
     robot.herokuKeepaliveIntervalId = setInterval =>
       robot.logger.info 'keepalive ping'
-      robot.http("#{keepaliveUrl}heroku/keepalive").post() (err, res, body) =>
-        if err?
-          robot.logger.info "keepalive pong: #{err}"
-          robot.emit 'error', err
-        else
-          robot.logger.info "keepalive pong: #{res.statusCode} #{body}"
+
+      now = new Date()
+      nowOffset    = 60 * now.getHours() + now.getMinutes()
+
+      if (nowOffset >= wakeUpOffset && nowOffset < sleepOffset)
+        robot.http("#{keepaliveUrl}heroku/keepalive").post() (err, res, body) =>
+          if err?
+            robot.logger.info "keepalive pong: #{err}"
+            robot.emit 'error', err
+          else
+            robot.logger.info "keepalive pong: #{res.statusCode} #{body}"
+      else
+        robot.logger.info "Skipping keep alive, time to rest"
+
     , keepaliveInterval * 60 * 1000
   else
     robot.logger.info "hubot-heroku-keepalive is #{keepaliveInterval}, so not keeping alive"


### PR DESCRIPTION
Based on @johnnaegle's changes in #9 to add `HUBOT_HEROKU_WAKEUP_TIME` and `HUBOT_HEROKU_SLEEP_TIME`, this adds docs on configuring [Heroku Scheduler](https://devcenter.heroku.com/articles/scheduler) to wake up the dyno. @JPrevost, thanks for the `curl` suggestion.

I rearranged some docs in the README (feedback welcome). The only substantive changes are in bd0aca4. [View rendered README](https://github.com/hubot-scripts/hubot-heroku-keepalive/blob/a2be5bcb38a9bd3fa0fbb0b433965abb605f68b1/README.md).

Here is the output of the scheduler running:

```
2015-08-21T16:42:05.006763+00:00 heroku[api]: Starting process with command `curl ${HUBOT_HEROKU_KEEPALIVE_URL}heroku/keepalive` by scheduler@addons.heroku.com
2015-08-21T16:42:07.351687+00:00 heroku[scheduler.3353]: Starting process with command `curl ${HUBOT_HEROKU_KEEPALIVE_URL}heroku/keepalive`
2015-08-21T16:42:08.042918+00:00 heroku[scheduler.3353]: State changed from starting to up
2015-08-21T16:42:09.516999+00:00 app[scheduler.3353]:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
2015-08-21T16:42:09.517256+00:00 app[scheduler.3353]:                                  Dload  Upload   Total   Spent    Left  Speed
100     2  100     2    0     0     36      0 --:--:-- --:--:-- --:--:--    37
2015-08-21T16:42:09.560455+00:00 heroku[router]: at=info method=GET path="/heroku/keepalive" host=polar-wildwood-2313.herokuapp.com request_id=d22b29f6-e2d8-4326-9a7b-090ec8585ab9 fwd="54.224.121.185" dyno=web.1 connect=1ms service=10ms status=200 bytes=186
2015-08-21T16:42:10.562058+00:00 heroku[scheduler.3353]: Process exited with status 0
2015-08-21T16:42:10.575225+00:00 heroku[scheduler.3353]: State changed from up to complete
```

/cc @technicalpickles 