### PR TITLE
Pointing out potential problems with timezones

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,11 @@ This script will keep the dyno alive once it is awake, but something needs to wa
 heroku addons:create scheduler:standard
 ```
 
-The scheduler must be manually configured from the web interface, so run `heroku addons:open scheduler` and configure it to run `curl ${HUBOT_HEROKU_KEEPALIVE_URL}heroku/keepalive` at the time configured for `HUBOT_HEROKU_WAKEUP_TIME`.
+The scheduler must be manually configured from the web interface, so run `heroku addons:open scheduler` and configure it to run `curl ${HUBOT_HEROKU_KEEPALIVE_URL}heroku/keepalive` at the time configured for `HUBOT_HEROKU_WAKEUP_TIME`. 
 
 ![Heroku Scheduler Screenshot](https://cloud.githubusercontent.com/assets/173/9414275/2e4b67ea-4805-11e5-80d0-d6b26ead50ef.png)
+
+Note that the Scheduler's time is in UTC. If you changed your application's timezone with `TZ`, you'll need to convert that time to UTC for the wakup job. For example, if `HUBOT_HEROKU_WAKEUP_TIME` is set to `06:00` and `TZ` is set to `America/New_York`, you'll need to set the Scheduler to run at 10:00 AM UTC.
 
 ## Legacy Support
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This script will keep the dyno alive once it is awake, but something needs to wa
 heroku addons:create scheduler:standard
 ```
 
-The scheduler must be manually configured from the web interface, so run `heroku addons:open scheduler` and configure it to run `curl ${HUBOT_HEROKU_KEEPALIVE_URL}heroku/keepalive` at the time configured for `HUBOT_HEROKU_WAKEUP_TIME`. 
+The scheduler must be manually configured from the web interface, so run `heroku addons:open scheduler` and configure it to run `curl ${HUBOT_HEROKU_KEEPALIVE_URL}heroku/keepalive` at the time configured for `HUBOT_HEROKU_WAKEUP_TIME`.
 
 ![Heroku Scheduler Screenshot](https://cloud.githubusercontent.com/assets/173/9414275/2e4b67ea-4805-11e5-80d0-d6b26ead50ef.png)
 


### PR DESCRIPTION
I got stung by this: My app was in `America/Chicago`, but Scheduler is in UTC, so Scheduler kept trying to wake up Hubot at 1AM, well within the sleep period. Once I realized the issue and adjusted Scheduler's time to 11AM, things worked fine. So, here's a note to help keep other folks from tripping up on this.