### PR TITLE
Minor fix, grep web-url instead of grep web_url

### DIFF
--- a/src/heroku-keepalive.coffee
+++ b/src/heroku-keepalive.coffee
@@ -40,7 +40,7 @@ module.exports = (robot) ->
                         5
 
   unless keepaliveUrl?
-    robot.logger.error "hubot-heroku-alive included, but missing HUBOT_HEROKU_KEEPALIVE_URL. `heroku config:set HUBOT_HEROKU_KEEPALIVE_URL=$(heroku apps:info -s  | grep web_url | cut -d= -f2)`"
+    robot.logger.error "hubot-heroku-alive included, but missing HUBOT_HEROKU_KEEPALIVE_URL. `heroku config:set HUBOT_HEROKU_KEEPALIVE_URL=$(heroku apps:info -s  | grep web-url | cut -d= -f2)`"
     return
 
   # check for legacy heroku keepalive from robot.coffee, and remove it


### PR DESCRIPTION
web_url was updated in README.md but not heroku-keepalive.coffee, not major.