### PR TITLE
Fix keepalive one-liner document and error message.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ heroku config:set HUBOT_HEROKU_KEEPALIVE_URL=PASTE_WEB_URL_HERE
 If you want to trust a shell snippet from the Internet, here's a one-liner:
 
 ```
-heroku config:set HUBOT_HEROKU_KEEPALIVE_URL=$(heroku apps:info -s | grep web-url | cut -d= -f2)
+heroku config:set HUBOT_HEROKU_KEEPALIVE_URL=$(heroku apps:info -s | grep web_url | cut -d= -f2)
 ```
 
 `HUBOT_HEROKU_WAKEUP_TIME` and `HUBOT_HEROKU_SLEEP_TIME` define the waking hours - between these times the keepalive will ping your Heroku app.  Outside of those times, the ping will be suppressed, allowing the dyno to shut down. These times are based on the timezone of your Heroku application which defaults to UTC.  You can change this with:

--- a/src/heroku-keepalive.coffee
+++ b/src/heroku-keepalive.coffee
@@ -40,7 +40,7 @@ module.exports = (robot) ->
                         5
 
   unless keepaliveUrl?
-    robot.logger.error "hubot-heroku-alive included, but missing HUBOT_HEROKU_KEEPALIVE_URL. `heroku config:set HUBOT_HEROKU_KEEPALIVE_URL=$(heroku apps:info -s  | grep web-url | cut -d= -f2)`"
+    robot.logger.error "hubot-heroku-alive included, but missing HUBOT_HEROKU_KEEPALIVE_URL. `heroku config:set HUBOT_HEROKU_KEEPALIVE_URL=$(heroku apps:info -s | grep web_url | cut -d= -f2)`"
     return
 
   # check for legacy heroku keepalive from robot.coffee, and remove it


### PR DESCRIPTION
Key name of web URL was changed to `web_url`.

```bash
$ heroku apps:info -s
...
web_url=https://app-name.herokuapp.com/
...
$ heroku version
heroku-toolbelt/3.43.9 (x86_64-darwin10.8.0) ruby/1.9.3
heroku-cli/5.2.39-010a227 (darwin-amd64) go1.6.2
```